### PR TITLE
add unit tests for snippet mapper and update mock data

### DIFF
--- a/clipvault-backend/Extensions/ServiceExtensions.cs
+++ b/clipvault-backend/Extensions/ServiceExtensions.cs
@@ -2,6 +2,7 @@ using ClipVault.Interfaces;
 using ClipVault.Services;
 using Microsoft.AspNetCore.Identity;
 using ClipVault.Models;
+using ClipVault.Mappers;
 
 namespace ClipVault.Extensions;
 

--- a/clipvault-backend/Mappers/SnippetMapper.cs
+++ b/clipvault-backend/Mappers/SnippetMapper.cs
@@ -2,6 +2,8 @@ using ClipVault.Dtos;
 using ClipVault.Interfaces;
 using ClipVault.Models;
 
+namespace ClipVault.Mappers;
+
 
 public class SnippetMapper : ISnippetMapper
 {

--- a/clipvault-backend/Tests/Mappers/SnippetMapperTests.cs
+++ b/clipvault-backend/Tests/Mappers/SnippetMapperTests.cs
@@ -1,0 +1,101 @@
+using ClipVault.Interfaces;
+using ClipVault.Tests.Mocks;
+using Moq;
+using Xunit;
+using ClipVault.Dtos;
+using ClipVault.Models;
+
+namespace ClipVault.Tests.Mappers
+{
+    public class SnippetMapperTests
+    {
+        private readonly Mock<ISnippetMapper> _mapperMock;
+        private readonly ISnippetMapper _mapper;
+
+        public SnippetMapperTests()
+        {
+            _mapperMock = new Mock<ISnippetMapper>();
+            _mapper = _mapperMock.Object;
+
+            // Mock setup for MapToSnippetResponseDto
+            _mapperMock.Setup(m => m.MapToSnippetResponseDto(It.IsAny<Snippet>()))
+                .Returns((Snippet snippet) => TestDataHelper.CreateSnippetResponseDto(snippet));
+
+            // Mock setup for MapToSnippetEntity
+            _mapperMock.Setup(m => m.MapToSnippetEntity(It.IsAny<SnippetCreateDto>(), It.IsAny<int>(), It.IsAny<List<Tag>>()))
+                .Returns((SnippetCreateDto dto, int languageId, List<Tag> tags) => TestDataHelper.CreateSnippet(dto, TestDataHelper.CreateLanguage()));
+
+            // Mock setup for MapToUpdateDto
+            _mapperMock.Setup(m => m.MapToUpdateDto(It.IsAny<SnippetResponseDto>()))
+                .Returns((SnippetResponseDto response) => TestDataHelper.CreateSnippetUpdateDto(response));
+        }
+
+        [Fact]
+        public void MapToSnippetResponseDto_ShouldMapCorrectly()
+        {
+            // Arrange
+            var snippetDto = TestDataHelper.CreateSnippetCreateDto();
+            var language = TestDataHelper.CreateLanguage();
+            var snippet = TestDataHelper.CreateSnippet(snippetDto, language);
+            snippet.SnippetTags = new List<SnippetTag>
+            {
+                new SnippetTag { Tag = new Tag { Name = "Tag1" } },
+                new SnippetTag { Tag = new Tag { Name = "Tag2" } }
+            };
+
+            // Act
+            var result = _mapper.MapToSnippetResponseDto(snippet);
+
+            var expectedTags = snippet.SnippetTags?
+                .Where(st => st != null && st.Tag != null)
+                .Select(st => st.Tag!.Name)
+                .ToList() ?? new List<string>();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(snippet.Id, result.Id);
+            Assert.Equal(snippet.Title, result.Title);
+            Assert.Equal(snippet.Code, result.Code);
+            Assert.Equal(snippet.Language?.Name ?? string.Empty, result.Language);
+            Assert.NotNull(result.Tags);
+            Assert.Equal(expectedTags, result.Tags);
+        }
+
+        [Fact]
+        public void MapToSnippetEntity_ShouldMapCorrectly()
+        {
+            // Arrange
+            var snippetDto = TestDataHelper.CreateSnippetCreateDto();
+            var tags = TestDataHelper.CreateTags();
+            int languageId = 1;
+
+            // Act
+            var result = _mapper.MapToSnippetEntity(snippetDto, languageId, tags);
+
+            // Assert
+            Assert.Equal(snippetDto.Title, result.Title);
+            Assert.Equal(snippetDto.Code, result.Code);
+            Assert.Equal(languageId, result.LanguageId);
+            Assert.NotNull(result.SnippetTags);
+            Assert.All(result.SnippetTags, st => Assert.NotNull(st.Tag));
+            Assert.All(result.SnippetTags, st => Assert.NotNull(st.Tag?.Name));
+            Assert.Equal(tags.Select(t => t.Id).ToList(), result.SnippetTags.Select(st => st.TagId).ToList());
+        }
+
+        [Fact]
+        public void MapToUpdateDto_ShouldMapCorrectly()
+        {
+            // Arrange
+            var snippetResponse = TestDataHelper.CreateSnippetResponseDto();
+
+            // Act
+            var result = _mapper.MapToUpdateDto(snippetResponse);
+
+            // Assert
+            Assert.Equal(snippetResponse.Title, result.Title);
+            Assert.Equal(snippetResponse.Code, result.Code);
+            Assert.Equal(snippetResponse.Language ?? string.Empty, result.Language);
+            Assert.Equal(snippetResponse.Tags ?? new List<string>(), result.TagNames);
+        }
+    }
+}

--- a/clipvault-backend/Tests/Mappers/SnippetMapperTests.cs
+++ b/clipvault-backend/Tests/Mappers/SnippetMapperTests.cs
@@ -21,10 +21,9 @@ namespace ClipVault.Tests.Mappers
             _mapperMock.Setup(m => m.MapToSnippetResponseDto(It.IsAny<Snippet>()))
                 .Returns((Snippet snippet) => TestDataHelper.CreateSnippetResponseDto(snippet));
 
-            // Mock setup for MapToSnippetEntity
             _mapperMock.Setup(m => m.MapToSnippetEntity(It.IsAny<SnippetCreateDto>(), It.IsAny<int>(), It.IsAny<List<Tag>>()))
-                .Returns((SnippetCreateDto dto, int languageId, List<Tag> tags) => TestDataHelper.CreateSnippet(dto, TestDataHelper.CreateLanguage()));
-
+            .Returns((SnippetCreateDto dto, int languageId, List<Tag> tags) =>
+                TestDataHelper.CreateSnippet(dto, languageId, tags));
             // Mock setup for MapToUpdateDto
             _mapperMock.Setup(m => m.MapToUpdateDto(It.IsAny<SnippetResponseDto>()))
                 .Returns((SnippetResponseDto response) => TestDataHelper.CreateSnippetUpdateDto(response));
@@ -36,7 +35,8 @@ namespace ClipVault.Tests.Mappers
             // Arrange
             var snippetDto = TestDataHelper.CreateSnippetCreateDto();
             var language = TestDataHelper.CreateLanguage();
-            var snippet = TestDataHelper.CreateSnippet(snippetDto, language);
+            var tags = TestDataHelper.CreateTags();
+            var snippet = TestDataHelper.CreateSnippet(snippetDto, language.Id, tags);
             snippet.SnippetTags = new List<SnippetTag>
             {
                 new SnippetTag { Tag = new Tag { Name = "Tag1" } },

--- a/clipvault-backend/Tests/Mocks/TestDataHelper.cs
+++ b/clipvault-backend/Tests/Mocks/TestDataHelper.cs
@@ -199,12 +199,9 @@ namespace ClipVault.Tests.Mocks
                 throw new ArgumentException($"Snippet with ID {snippetId} not found.");
             }
 
-            foreach (var tag in tagsToAdd)
+            foreach (var tag in tagsToAdd.Where(tag => !snippet.SnippetTags.Any(st => st.TagId == tag.Id)))
             {
-                if (!snippet.SnippetTags.Any(st => st.TagId == tag.Id))
-                {
-                    snippet.SnippetTags.Add(new SnippetTag { TagId = tag.Id, Tag = tag });
-                }
+                snippet.SnippetTags.Add(new SnippetTag { TagId = tag.Id, Tag = tag });
             }
         }
     }

--- a/clipvault-backend/Tests/Mocks/TestDataHelper.cs
+++ b/clipvault-backend/Tests/Mocks/TestDataHelper.cs
@@ -78,7 +78,12 @@ namespace ClipVault.Tests.Mocks
                 Id = 1,
                 Title = snippetDto.Title,
                 Code = snippetDto.Code,
-                LanguageId = language.Id
+                LanguageId = language.Id,
+                SnippetTags = snippetDto.TagNames.Select((tagName, index) => new SnippetTag
+                {
+                    TagId = index + 1,
+                    Tag = new Tag { Id = index + 1, Name = tagName }
+                }).ToList()
             };
         }
 
@@ -109,6 +114,17 @@ namespace ClipVault.Tests.Mocks
                 UserName = registerDto.UserName,
                 Email = registerDto.Email,
                 PasswordHash = "hashedpassword"
+            };
+        }
+
+        public static SnippetUpdateDto CreateSnippetUpdateDto(SnippetResponseDto response)
+        {
+            return new SnippetUpdateDto
+            {
+                Title = response.Title,
+                Code = response.Code,
+                Language = response.Language,
+                TagNames = response.Tags
             };
         }
     }

--- a/clipvault-backend/Tests/Mocks/TestDataHelper.cs
+++ b/clipvault-backend/Tests/Mocks/TestDataHelper.cs
@@ -64,25 +64,30 @@ namespace ClipVault.Tests.Mocks
 
         public static List<Tag> CreateTags()
         {
-            return
-            [
+            return new List<Tag>
+            {
                 new Tag { Id = 1, Name = "example" },
-                new Tag { Id = 2, Name = "test" }
-            ];
+                new Tag { Id = 2, Name = "test" },
+            };
         }
 
-        public static Snippet CreateSnippet(SnippetCreateDto snippetDto, Language language)
+        public static List<Tag> CreateTags(List<Tag> tags)
+        {
+            return tags.Select(tag => new Tag { Id = tag.Id, Name = tag.Name }).ToList();
+        }
+        public static Snippet CreateSnippet(SnippetCreateDto snippetDto, int languageId, List<Tag> tags)
         {
             return new Snippet
             {
                 Id = 1,
                 Title = snippetDto.Title,
                 Code = snippetDto.Code,
-                LanguageId = language.Id,
-                SnippetTags = snippetDto.TagNames.Select((tagName, index) => new SnippetTag
+                LanguageId = languageId,
+                Language = new Language { Id = languageId, Name = snippetDto.Language },
+                SnippetTags = tags.Select(tag => new SnippetTag
                 {
-                    TagId = index + 1,
-                    Tag = new Tag { Id = index + 1, Name = tagName }
+                    TagId = tag.Id, // Ensure TagId is set
+                    Tag = tag
                 }).ToList()
             };
         }
@@ -126,6 +131,81 @@ namespace ClipVault.Tests.Mocks
                 Language = response.Language,
                 TagNames = response.Tags
             };
+        }
+
+        public static List<Snippet> CreateSnippetList()
+        {
+            var language1 = new Language { Id = 1, Name = "C#" };
+            var language2 = new Language { Id = 2, Name = "Python" };
+
+            var tags1 = new List<Tag>
+            {
+                new Tag { Id = 1, Name = "example" },
+                new Tag { Id = 2, Name = "test" }
+            };
+
+            var tags2 = new List<Tag>
+            {
+                new Tag { Id = 3, Name = "automation" },
+                new Tag { Id = 4, Name = "scripting" }
+            };
+
+            var snippet1 = new Snippet
+            {
+                Id = 1,
+                Title = "Snippet 1",
+                Code = "Code 1",
+                LanguageId = language2.Id,
+                Language = language2,
+                SnippetTags = tags2.Select(tag => new SnippetTag
+                {
+                    TagId = tag.Id,
+                    Tag = tag
+                }).ToList()
+            };
+
+            var snippet2 = new Snippet
+            {
+                Id = 2,
+                Title = "Snippet 2",
+                Code = "Code 2",
+                LanguageId = language1.Id,
+                Language = language1,
+                SnippetTags = tags1.Select(tag => new SnippetTag
+                {
+                    TagId = tag.Id,
+                    Tag = tag
+                }).ToList()
+            };
+
+            var snippet3 = new Snippet
+            {
+                Id = 3,
+                Title = "Snippet 3",
+                Code = "Code 3",
+                LanguageId = language1.Id,
+                Language = language1,
+                SnippetTags = new List<SnippetTag>() // Empty for AddTagsToSnippetAsync test
+            };
+
+            return new List<Snippet> { snippet1, snippet2, snippet3 };
+        }
+
+        public static void AddTagsToSnippet(List<Snippet> snippets, int snippetId, List<Tag> tagsToAdd)
+        {
+            var snippet = snippets.FirstOrDefault(s => s.Id == snippetId);
+            if (snippet == null)
+            {
+                throw new ArgumentException($"Snippet with ID {snippetId} not found.");
+            }
+
+            foreach (var tag in tagsToAdd)
+            {
+                if (!snippet.SnippetTags.Any(st => st.TagId == tag.Id))
+                {
+                    snippet.SnippetTags.Add(new SnippetTag { TagId = tag.Id, Tag = tag });
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces new unit tests for the snippet mapper and updates the mock data helper to support snippet tag mapping. Key changes include:

- Updating TestDataHelper to generate SnippetTags based on TagNames in SnippetCreateDto.
- Adding unit tests in SnippetMapperTests for mapping to response, entity, and update DTOs.
- Including the SnippetMapper namespace in both the mapper and service extension files to ensure proper dependency injection.