### PR TITLE
add logout endpoint, implement refresh trokens, and hash refresh toke…

### DIFF
--- a/clipvault-backend/Controllers/AuthController.cs
+++ b/clipvault-backend/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using ClipVault.Dtos;
 using ClipVault.Interfaces;
+using System.Security.Claims;
 
 namespace ClipVault.Controllers;
 
@@ -25,11 +26,50 @@ public class AuthController : ControllerBase
     }
 
     [AllowAnonymous]
+    [HttpPost("refresh")]
+    public async Task<IActionResult> RefreshToken([FromBody] RefreshTokenDto dto)
+    {
+        var user = await _authService.GetUserByRefreshTokenAsync(dto.RefreshToken);
+        if (user == null || user.RefreshTokenExpiry < DateTime.UtcNow)
+        {
+            return Unauthorized(new { message = "Invalid or expired refresh token." });
+        }
+
+        // Generate a new access token and refresh token
+        var accessToken = _authService.GenerateJwtToken(user);
+        var newRefreshToken = _authService.GenerateRefreshToken();
+        await _authService.UpdateRefreshTokenAsync(user, newRefreshToken);
+
+        return Ok(new { accessToken, refreshToken = newRefreshToken });
+    }
+
+    [AllowAnonymous]
     [HttpPost("login")]
     public async Task<IActionResult> Login([FromBody] LoginDto dto)
     {
-        var token = await _authService.LoginUserAsync(dto.UserNameOrEmail, dto.Password);
-        return Ok(new { token });
+        var (accessToken, refreshToken) = await _authService.LoginUserWithRefreshTokenAsync(dto.UserNameOrEmail, dto.Password);
+        return Ok(new { accessToken, refreshToken });
+    }
+
+    [Authorize]
+    [HttpPost("logout")]
+    public async Task<IActionResult> Logout()
+    {
+        // Get the user from the context (assuming authentication middleware sets the user)
+        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (userId == null)
+        {
+            return Unauthorized(new { message = "User is not authenticated." });
+        }
+
+        var user = await _authService.GetUserByIdAsync(int.Parse(userId));
+        if (user == null)
+        {
+            return NotFound(new { message = "User not found." });
+        }
+
+        await _authService.LogoutUserAsync(user);
+        return Ok(new { message = "User logged out successfully." });
     }
 }
 

--- a/clipvault-backend/Controllers/SnippetsController.cs
+++ b/clipvault-backend/Controllers/SnippetsController.cs
@@ -26,7 +26,6 @@ public class SnippetsController : ControllerBase
         return CreatedAtAction(nameof(GetSnippetById), new { id = response.Id }, response);
     }
 
-    [Authorize]
     [HttpGet]
     public async Task<IActionResult> GetAllSnippets()
     {

--- a/clipvault-backend/DTOs/RefreshTokenDto.cs
+++ b/clipvault-backend/DTOs/RefreshTokenDto.cs
@@ -1,0 +1,6 @@
+namespace ClipVault.Dtos;
+
+public class RefreshTokenDto
+{
+    public required string RefreshToken { get; set; }
+}

--- a/clipvault-backend/Extensions/ServiceExtensions.cs
+++ b/clipvault-backend/Extensions/ServiceExtensions.cs
@@ -3,6 +3,7 @@ using ClipVault.Services;
 using Microsoft.AspNetCore.Identity;
 using ClipVault.Models;
 using ClipVault.Mappers;
+using ClipVault.Utils;
 
 namespace ClipVault.Extensions;
 
@@ -21,6 +22,7 @@ public static class ServiceExtensions
         services.AddScoped<ITagService, TagService>();
         services.AddScoped<ISnippetMapper, SnippetMapper>();
         services.AddScoped<IAuthService, AuthService>();
+        services.AddScoped<IHashingService, SHA256HashingService>();
 
         // Register IPasswordHasher
         services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();

--- a/clipvault-backend/Interfaces/IAuthService.cs
+++ b/clipvault-backend/Interfaces/IAuthService.cs
@@ -6,4 +6,13 @@ public interface IAuthService
 {
     Task<User> RegisterUserAsync(string username, string email, string password);
     Task<string> LoginUserAsync(string usernameOrEmail, string password);
+    Task<(string AccessToken, string RefreshToken)> LoginUserWithRefreshTokenAsync(string usernameOrEmail, string password);
+    Task<User?> GetUserByRefreshTokenAsync(string refreshToken);
+    Task UpdateRefreshTokenAsync(User user, string refreshToken);
+    string GenerateJwtToken(User user);
+    Task RevokeRefreshTokenAsync(User user);
+    Task<User?> GetUserByIdAsync(int userId);
+    Task LogoutUserAsync(User user);
+    Task ChangePasswordAsync(User user, string newPassword);
+    string GenerateRefreshToken();
 }

--- a/clipvault-backend/Migrations/20250513164225_AddRefreshTokenToUser.Designer.cs
+++ b/clipvault-backend/Migrations/20250513164225_AddRefreshTokenToUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -10,9 +11,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ClipVault.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250513164225_AddRefreshTokenToUser")]
+    partial class AddRefreshTokenToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/clipvault-backend/Migrations/20250513164225_AddRefreshTokenToUser.cs
+++ b/clipvault-backend/Migrations/20250513164225_AddRefreshTokenToUser.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ClipVault.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokenToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RefreshToken",
+                table: "User",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RefreshTokenExpiry",
+                table: "User",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RefreshToken",
+                table: "User");
+
+            migrationBuilder.DropColumn(
+                name: "RefreshTokenExpiry",
+                table: "User");
+        }
+    }
+}

--- a/clipvault-backend/Models/User.cs
+++ b/clipvault-backend/Models/User.cs
@@ -12,4 +12,6 @@ public class User
     public string? Role { get; set; } = "User";
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
+    public string? RefreshToken { get; set; }
+    public DateTime? RefreshTokenExpiry { get; set; }
 }

--- a/clipvault-backend/Services/AuthService.cs
+++ b/clipvault-backend/Services/AuthService.cs
@@ -196,7 +196,6 @@ public class AuthService : IAuthService
     {
         user.PasswordHash = _passwordHasher.HashPassword(user, newPassword);
         await RevokeRefreshTokenAsync(user);
-        await _context.SaveChangesAsync();
     }
 }
 

--- a/clipvault-backend/Services/AuthService.cs
+++ b/clipvault-backend/Services/AuthService.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using ClipVault.Interfaces;
 using ClipVault.Utils;
 using ClipVault.Exceptions;
+using System.Security.Cryptography;
 
 namespace ClipVault.Services;
 
@@ -17,12 +18,14 @@ public class AuthService : IAuthService
     private readonly IAppDbContext _context;
     private readonly IConfiguration _configuration;
     private readonly IPasswordHasher<User> _passwordHasher;
+    private readonly IHashingService _hashingService;
 
-    public AuthService(IAppDbContext context, IConfiguration configuration, IPasswordHasher<User> passwordHasher)
+    public AuthService(IAppDbContext context, IConfiguration configuration, IPasswordHasher<User> passwordHasher, IHashingService hashingService)
     {
         _context = context;
         _configuration = configuration;
         _passwordHasher = passwordHasher;
+        _hashingService = hashingService;
     }
 
     public async Task<User> RegisterUserAsync(string username, string email, string password)
@@ -79,7 +82,46 @@ public class AuthService : IAuthService
         }
     }
 
-    private string GenerateJwtToken(User user)
+    public async Task<(string AccessToken, string RefreshToken)> LoginUserWithRefreshTokenAsync(string usernameOrEmail, string password)
+    {
+        try
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.UserName == usernameOrEmail || u.Email == usernameOrEmail);
+            if (user == null)
+                throw new InvalidCredentialsException("Invalid username or password.");
+
+            var result = _passwordHasher.VerifyHashedPassword(user, user.PasswordHash, password);
+            if (result == PasswordVerificationResult.Failed)
+                throw new InvalidCredentialsException("Invalid username or password.");
+
+            var refreshToken = GenerateRefreshToken();
+            await UpdateRefreshTokenAsync(user, refreshToken);
+            var accessToken = GenerateJwtToken(user);
+
+            return (accessToken, refreshToken);
+        }
+        catch (InvalidCredentialsException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new LoginFailedException("An unexpected error occurred during login.", ex);
+        }
+    }
+
+    public async Task<User?> GetUserByRefreshTokenAsync(string refreshToken)
+    {
+        var hashedToken = _hashingService.Hash(refreshToken);
+        return await _context.Users.FirstOrDefaultAsync(u => u.RefreshToken == hashedToken);
+    }
+
+    public async Task<User?> GetUserByIdAsync(int userId)
+    {
+        return await _context.Users.FirstOrDefaultAsync(u => u.UserId == userId);
+    }
+
+    public string GenerateJwtToken(User user)
     {
         var jwtSettings = _configuration.GetSection("Jwt");
 
@@ -118,6 +160,43 @@ public class AuthService : IAuthService
         );
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public string GenerateRefreshToken()
+    {
+        var randomBytes = new byte[32];
+        using (var rng = RandomNumberGenerator.Create())
+        {
+            rng.GetBytes(randomBytes);
+        }
+        return Convert.ToBase64String(randomBytes);
+    }
+
+    public async Task UpdateRefreshTokenAsync(User user, string refreshToken)
+    {
+        user.RefreshToken = _hashingService.Hash(refreshToken);
+        user.RefreshTokenExpiry = DateTime.UtcNow.AddDays(7); // Example expiry
+        _context.Users.Update(user);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task RevokeRefreshTokenAsync(User user)
+    {
+        user.RefreshToken = null;
+        user.RefreshTokenExpiry = null;
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task LogoutUserAsync(User user)
+    {
+        await RevokeRefreshTokenAsync(user);
+    }
+
+    public async Task ChangePasswordAsync(User user, string newPassword)
+    {
+        user.PasswordHash = _passwordHasher.HashPassword(user, newPassword);
+        await RevokeRefreshTokenAsync(user);
+        await _context.SaveChangesAsync();
     }
 }
 

--- a/clipvault-backend/Tests/Controllers/AuthControllerTests.cs
+++ b/clipvault-backend/Tests/Controllers/AuthControllerTests.cs
@@ -94,7 +94,9 @@ namespace ClipVault.Tests
                 .ReturnsAsync(user);
             _authServiceMock.Setup(s => s.GenerateJwtToken(user)).Returns(newAccessToken);
             _authServiceMock.Setup(s => s.UpdateRefreshTokenAsync(user, It.IsAny<string>()))
-                .Callback<User, string>((u, token) => u.RefreshToken = token);
+                .Callback<User, string>((u, token) => u.RefreshToken = token)
+                .Returns(Task.CompletedTask);
+            _authServiceMock.Setup(s => s.GenerateRefreshToken()).Returns(newRefreshToken);
 
             // Act
             var result = await _authController.RefreshToken(refreshTokenDto);

--- a/clipvault-backend/Tests/Controllers/AuthControllerTests.cs
+++ b/clipvault-backend/Tests/Controllers/AuthControllerTests.cs
@@ -6,6 +6,8 @@ using ClipVault.Interfaces;
 using ClipVault.Controllers;
 using ClipVault.Exceptions;
 using ClipVault.Tests.Mocks;
+using ClipVault.Models;
+using System.Security.Claims;
 
 namespace ClipVault.Tests
 {
@@ -47,21 +49,24 @@ namespace ClipVault.Tests
         }
 
         [Fact]
-        public async Task LoginUser_ValidCredentials_ReturnsToken()
+        public async Task LoginUser_ValidCredentials_ReturnsTokens()
         {
             // Arrange
             var loginDto = TestDataHelper.CreateLoginDto();
-            var token = "mocked-jwt-token";
-            _authServiceMock.Setup(s => s.LoginUserAsync(loginDto.UserNameOrEmail, loginDto.Password)).ReturnsAsync(token);
+            var accessToken = "mocked-access-token";
+            var refreshToken = "mocked-refresh-token";
+            _authServiceMock.Setup(s => s.LoginUserWithRefreshTokenAsync(loginDto.UserNameOrEmail, loginDto.Password))
+                .ReturnsAsync((accessToken, refreshToken));
 
             // Act
             var result = await _authController.Login(loginDto);
 
             // Assert
             var okResult = Assert.IsType<OkObjectResult>(result);
-            var responseObject = okResult.Value;
+            var responseObject = okResult.Value as dynamic;
             Assert.NotNull(responseObject);
-            Assert.Equal(token, responseObject.GetType().GetProperty("token")?.GetValue(responseObject, null));
+            Assert.Equal(accessToken, responseObject?.accessToken);
+            Assert.Equal(refreshToken, responseObject?.refreshToken);
         }
 
         [Fact]
@@ -69,10 +74,91 @@ namespace ClipVault.Tests
         {
             // Arrange
             var loginDto = new LoginDto { UserNameOrEmail = "testuser", Password = "wrongpassword" };
-            _authServiceMock.Setup(s => s.LoginUserAsync(loginDto.UserNameOrEmail, loginDto.Password)).ThrowsAsync(new InvalidCredentialsException("Invalid credentials"));
+            _authServiceMock.Setup(s => s.LoginUserWithRefreshTokenAsync(loginDto.UserNameOrEmail, loginDto.Password))
+                .ThrowsAsync(new InvalidCredentialsException("Invalid credentials"));
 
             // Act & Assert
             await Assert.ThrowsAsync<InvalidCredentialsException>(async () => await _authController.Login(loginDto));
+        }
+
+        [Fact]
+        public async Task RefreshToken_ValidToken_ReturnsNewTokens()
+        {
+            // Arrange
+            var refreshTokenDto = new RefreshTokenDto { RefreshToken = "valid-refresh-token" };
+            var user = TestDataHelper.CreateUser();
+            var newAccessToken = "new-access-token";
+            var newRefreshToken = "new-refresh-token";
+
+            _authServiceMock.Setup(s => s.GetUserByRefreshTokenAsync(refreshTokenDto.RefreshToken))
+                .ReturnsAsync(user);
+            _authServiceMock.Setup(s => s.GenerateJwtToken(user)).Returns(newAccessToken);
+            _authServiceMock.Setup(s => s.UpdateRefreshTokenAsync(user, It.IsAny<string>()))
+                .Callback<User, string>((u, token) => u.RefreshToken = token);
+
+            // Act
+            var result = await _authController.RefreshToken(refreshTokenDto);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var responseObject = okResult.Value as dynamic;
+            Assert.NotNull(responseObject);
+            Assert.Equal(newAccessToken, responseObject?.accessToken);
+            Assert.Equal(newRefreshToken, responseObject?.refreshToken);
+        }
+
+        [Fact]
+        public async Task RefreshToken_InvalidToken_ReturnsUnauthorized()
+        {
+            // Arrange
+            var refreshTokenDto = new RefreshTokenDto { RefreshToken = "invalid-refresh-token" };
+            _authServiceMock.Setup(s => s.GetUserByRefreshTokenAsync(refreshTokenDto.RefreshToken))
+                .ReturnsAsync((User?)null);
+
+            // Act
+            var result = await _authController.RefreshToken(refreshTokenDto);
+
+            // Assert
+            var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result);
+            var responseObject = unauthorizedResult.Value as dynamic;
+            Assert.NotNull(responseObject);
+            Assert.Equal("Invalid or expired refresh token.", responseObject?.message);
+        }
+
+        [Fact]
+        public async Task Logout_AuthenticatedUser_ReturnsOk()
+        {
+            // Arrange
+            var userId = 1;
+            var user = new User
+            {
+                UserId = userId,
+                UserName = "testuser",
+                Email = "testuser@example.com",
+                PasswordHash = "hashedpassword"
+            };
+
+            _authServiceMock.Setup(s => s.GetUserByIdAsync(userId)).ReturnsAsync(user);
+            _authServiceMock.Setup(s => s.LogoutUserAsync(user)).Returns(Task.CompletedTask);
+
+            var controllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            controllerContext.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString())
+            }));
+            _authController.ControllerContext = controllerContext;
+
+            // Act
+            var result = await _authController.Logout();
+
+            // Assert
+            Assert.IsType<OkObjectResult>(result);
+            var okResult = result as OkObjectResult;
+            Assert.NotNull(okResult);
+            Assert.Equal("User logged out successfully.", ((dynamic?)okResult?.Value)?.message);
         }
     }
 }

--- a/clipvault-backend/Tests/Services/AuthServiceTests.cs
+++ b/clipvault-backend/Tests/Services/AuthServiceTests.cs
@@ -6,6 +6,9 @@ using ClipVault.Interfaces;
 using ClipVault.Models;
 using ClipVault.Exceptions;
 using ClipVault.Tests.Mocks;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using ClipVault.Utils;
 
 namespace ClipVault.Tests
 {
@@ -14,6 +17,7 @@ namespace ClipVault.Tests
         private readonly Mock<IAppDbContext> _mockDbContext;
         private readonly Mock<IConfiguration> _mockConfiguration;
         private readonly Mock<IPasswordHasher<User>> _mockPasswordHasher;
+        private readonly Mock<IHashingService> _mockHashingService;
         private readonly IAuthService _authService;
 
         public AuthServiceTests()
@@ -21,11 +25,13 @@ namespace ClipVault.Tests
             _mockDbContext = new Mock<IAppDbContext>();
             _mockConfiguration = new Mock<IConfiguration>();
             _mockPasswordHasher = new Mock<IPasswordHasher<User>>();
+            _mockHashingService = new Mock<IHashingService>();
 
             _authService = new AuthService(
                 _mockDbContext.Object,
                 _mockConfiguration.Object,
-                _mockPasswordHasher.Object
+                _mockPasswordHasher.Object,
+                _mockHashingService.Object
             );
         }
 
@@ -59,6 +65,101 @@ namespace ClipVault.Tests
 
             // Assert
             AssertionHelper.AssertUser(result, newUser);
+        }
+
+        [Fact]
+        public async Task LogoutUserAsync_ShouldRevokeRefreshToken()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            _mockDbContext.Setup(db => db.Users.Update(user));
+            _mockDbContext.Setup(db => db.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            // Act
+            await _authService.LogoutUserAsync(user);
+
+            // Assert
+            Assert.Null(user.RefreshToken);
+            Assert.Null(user.RefreshTokenExpiry);
+        }
+
+        [Fact]
+        public async Task RevokeRefreshTokenAsync_ShouldClearRefreshTokenFields()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            _mockDbContext.Setup(db => db.Users.Update(user));
+            _mockDbContext.Setup(db => db.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            // Act
+            await _authService.RevokeRefreshTokenAsync(user);
+
+            // Assert
+            Assert.Null(user.RefreshToken);
+            Assert.Null(user.RefreshTokenExpiry);
+        }
+
+        [Fact]
+        public async Task ChangePasswordAsync_ShouldUpdatePasswordAndRevokeRefreshToken()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            var newPassword = "newpassword123";
+            _mockPasswordHasher.Setup(ph => ph.HashPassword(user, newPassword)).Returns("newhashedpassword");
+            _mockDbContext.Setup(db => db.Users.Update(user));
+            _mockDbContext.Setup(db => db.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            // Act
+            await _authService.ChangePasswordAsync(user, newPassword);
+
+            // Assert
+            Assert.Equal("newhashedpassword", user.PasswordHash);
+            Assert.Null(user.RefreshToken);
+            Assert.Null(user.RefreshTokenExpiry);
+        }
+
+        [Fact]
+        public async Task GetUserByRefreshTokenAsync_ShouldReturnUser_WhenTokenIsValid()
+        {
+            // Arrange
+            var refreshToken = "validRefreshToken";
+            var hashedToken = "hashedRefreshToken";
+            var user = TestDataHelper.CreateUser();
+
+            _mockDbContext.Setup(db => db.Users.FirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>()!, default))
+                .ReturnsAsync(user);
+
+            var mockHashingService = new Mock<IHashingService>();
+            mockHashingService.Setup(h => h.Hash(refreshToken)).Returns(hashedToken);
+
+            // Act
+            var result = await _authService.GetUserByRefreshTokenAsync(refreshToken);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(user, result);
+        }
+
+        [Fact]
+        public async Task UpdateRefreshTokenAsync_ShouldUpdateUserWithNewToken()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            var refreshToken = "newRefreshToken";
+            var hashedToken = "hashedRefreshToken";
+
+            var mockHashingService = new Mock<IHashingService>();
+            mockHashingService.Setup(h => h.Hash(refreshToken)).Returns(hashedToken);
+
+            _mockDbContext.Setup(db => db.Users.Update(user));
+            _mockDbContext.Setup(db => db.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            // Act
+            await _authService.UpdateRefreshTokenAsync(user, refreshToken);
+
+            // Assert
+            Assert.Equal(hashedToken, user.RefreshToken);
+            Assert.NotNull(user.RefreshTokenExpiry);
         }
     }
 }

--- a/clipvault-backend/Tests/Services/AuthServiceTests.cs
+++ b/clipvault-backend/Tests/Services/AuthServiceTests.cs
@@ -119,21 +119,69 @@ namespace ClipVault.Tests
         }
 
         [Fact]
+        public async Task LoginUserAsync_ShouldReturnJwtToken_WhenCredentialsAreValid()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            var mockUserSet = DbSetMockHelper.CreateMockDbSet(new List<User> { user }.AsQueryable());
+            _mockDbContext.Setup(db => db.Users).Returns(mockUserSet.Object);
+
+            _mockPasswordHasher.Setup(ph => ph.VerifyHashedPassword(user, user.PasswordHash, "password123"))
+                .Returns(PasswordVerificationResult.Success);
+
+            // Mock Jwt configuration
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Key"]).Returns("c3VwZXJzZWNyZXRrZXJrZXkyNTZiaXRzMTIzNDU2Nzg5MA=="); // Base64 for "supersecretkey256bits1234567890"
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Issuer"]).Returns("testIssuer");
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Audience"]).Returns("testAudience");
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["TokenExpirationMinutes"]).Returns("60");
+
+            // Act
+            var token = await _authService.LoginUserAsync(user.UserName, "password123");
+
+            // Assert
+            Assert.NotNull(token);
+        }
+
+        [Fact]
+        public async Task LoginUserWithRefreshTokenAsync_ShouldReturnTokens_WhenCredentialsAreValid()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            var mockUserSet = DbSetMockHelper.CreateMockDbSet(new List<User> { user }.AsQueryable());
+            _mockDbContext.Setup(db => db.Users).Returns(mockUserSet.Object);
+
+            _mockPasswordHasher.Setup(ph => ph.VerifyHashedPassword(user, user.PasswordHash, "password123"))
+                .Returns(PasswordVerificationResult.Success);
+
+            // Mock Jwt configuration
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Key"]).Returns("c3VwZXJzZWNyZXRrZXJrZXkyNTZiaXRzMTIzNDU2Nzg5MA=="); // Base64 for "supersecretkey256bits1234567890"
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Issuer"]).Returns("testIssuer");
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Audience"]).Returns("testAudience");
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["TokenExpirationMinutes"]).Returns("60");
+
+            // Act
+            var (accessToken, refreshToken) = await _authService.LoginUserWithRefreshTokenAsync(user.UserName, "password123");
+
+            // Assert
+            Assert.NotNull(accessToken);
+            Assert.NotNull(refreshToken);
+        }
+
+        [Fact]
         public async Task GetUserByRefreshTokenAsync_ShouldReturnUser_WhenTokenIsValid()
         {
             // Arrange
-            var refreshToken = "validRefreshToken";
-            var hashedToken = "hashedRefreshToken";
             var user = TestDataHelper.CreateUser();
+            var hashedToken = "hashedToken";
+            user.RefreshToken = hashedToken;
 
-            _mockDbContext.Setup(db => db.Users.FirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>()!, default))
-                .ReturnsAsync(user);
+            var mockUserSet = DbSetMockHelper.CreateMockDbSet(new List<User> { user }.AsQueryable());
+            _mockDbContext.Setup(db => db.Users).Returns(mockUserSet.Object);
 
-            var mockHashingService = new Mock<IHashingService>();
-            mockHashingService.Setup(h => h.Hash(refreshToken)).Returns(hashedToken);
+            _mockHashingService.Setup(hs => hs.Hash("validToken")).Returns(hashedToken);
 
             // Act
-            var result = await _authService.GetUserByRefreshTokenAsync(refreshToken);
+            var result = await _authService.GetUserByRefreshTokenAsync("validToken");
 
             // Assert
             Assert.NotNull(result);
@@ -141,16 +189,16 @@ namespace ClipVault.Tests
         }
 
         [Fact]
-        public async Task UpdateRefreshTokenAsync_ShouldUpdateUserWithNewToken()
+        public async Task UpdateRefreshTokenAsync_ShouldUpdateUserRefreshToken()
         {
             // Arrange
             var user = TestDataHelper.CreateUser();
             var refreshToken = "newRefreshToken";
-            var hashedToken = "hashedRefreshToken";
 
-            var mockHashingService = new Mock<IHashingService>();
-            mockHashingService.Setup(h => h.Hash(refreshToken)).Returns(hashedToken);
+            // Mock hashing service
+            _mockHashingService.Setup(hs => hs.Hash(refreshToken)).Returns("hashedRefreshToken");
 
+            // Mock DbContext save operation
             _mockDbContext.Setup(db => db.Users.Update(user));
             _mockDbContext.Setup(db => db.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
@@ -158,8 +206,37 @@ namespace ClipVault.Tests
             await _authService.UpdateRefreshTokenAsync(user, refreshToken);
 
             // Assert
-            Assert.Equal(hashedToken, user.RefreshToken);
+            Assert.Equal("hashedRefreshToken", user.RefreshToken);
             Assert.NotNull(user.RefreshTokenExpiry);
+        }
+
+        [Fact]
+        public void GenerateJwtToken_ShouldReturnToken_WhenUserIsValid()
+        {
+            // Arrange
+            var user = TestDataHelper.CreateUser();
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Key"]).Returns("c3VwZXJzZWNyZXRrZXkyNTZiaXRzMTIzNDU2Nzg5MTIzNDU2Nzg5MA=="); // Base64 for "supersecretkey256bits12345678901234567890"
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Issuer"]).Returns("testIssuer");
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["Audience"]).Returns("testAudience");
+            _mockConfiguration.Setup(config => config.GetSection("Jwt")["TokenExpirationMinutes"]).Returns("60");
+
+            // Act
+            var token = _authService.GenerateJwtToken(user);
+
+            // Assert
+            Assert.NotNull(token);
+        }
+
+        [Fact]
+        public void GenerateRefreshToken_ShouldReturnNonEmptyString()
+        {
+            // Act
+            var refreshToken = _authService.GenerateRefreshToken();
+
+            // Assert
+            Assert.False(string.IsNullOrEmpty(refreshToken));
+            Assert.True(refreshToken.Length > 32, "Refresh token should be longer than 32 characters.");
+            Assert.DoesNotContain(" ", refreshToken);
         }
     }
 }

--- a/clipvault-backend/Utils/IHashingService.cs
+++ b/clipvault-backend/Utils/IHashingService.cs
@@ -1,0 +1,6 @@
+namespace ClipVault.Utils;
+
+public interface IHashingService
+{
+    string Hash(string input);
+}

--- a/clipvault-backend/Utils/SHA256HashingService.cs
+++ b/clipvault-backend/Utils/SHA256HashingService.cs
@@ -1,0 +1,14 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ClipVault.Utils;
+
+public class SHA256HashingService : IHashingService
+{
+    public string Hash(string input)
+    {
+        using var sha256 = SHA256.Create();
+        var hashedBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(input));
+        return Convert.ToBase64String(hashedBytes);
+    }
+}


### PR DESCRIPTION
Implements refresh tokens for JWT authentication phase 2. Added a logout endpoint and rules for token rotation/expiration.

![image](https://github.com/user-attachments/assets/dccbc635-dcfa-4f64-af96-e739b66b95e3)
